### PR TITLE
Add per-model IP CIDR policies (`model_ip_policies`) with enforcement and docs

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -251,6 +251,7 @@ router_settings:
 | alerting_args | dict | Args for Slack Alerting [Doc on Slack Alerting](./alerting.md) |
 | custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom--key-generate) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |
+| model_ip_policies | List[ModelIPPolicy] | Per-model IP allow policy. If a request model matches policy `model`, client IP must be inside one of `allow_cidrs` CIDRs. Example: `[{"model":"gpt-4o","allow_cidrs":["10.0.0.0/8"]}]`. |
 | embedding_model | str | The default model to use for embeddings - ignores model set in request |
 | default_team_disabled | boolean | If true, users cannot create 'personal' keys (keys with no team_id). |
 | alert_to_webhook_url | Dict[str] | [Specify a webhook url for each alert type.](./alerting.md#set-specific-slack-channels-per-alert-type) |

--- a/docs/my-website/docs/proxy/ip_address.md
+++ b/docs/my-website/docs/proxy/ip_address.md
@@ -26,3 +26,22 @@ general_settings:
     }
 }
 ```
+
+## Model-specific IP CIDR policies
+
+You can additionally restrict specific models to specific CIDR ranges using `general_settings.model_ip_policies`.
+
+```yaml
+general_settings:
+  use_x_forwarded_for: true
+  model_ip_policies:
+    - model: "gpt-4o"
+      allow_cidrs: ["10.20.0.0/16", "192.168.100.0/24"]
+    - model: "anthropic/*"
+      allow_cidrs: ["172.16.0.0/12"]
+```
+
+- `model` supports exact match and `*` suffix wildcard patterns.
+- If the request model matches a policy and client IP is outside `allow_cidrs`, the request is rejected with HTTP 403.
+- For deployments behind reverse proxies, set `use_x_forwarded_for: true` and configure trusted proxy ranges to avoid spoofed `X-Forwarded-For` headers.
+

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1985,6 +1985,19 @@ class UserHeaderMapping(LiteLLMPydanticObjectBase):
 UserMCPManagementMode = Literal["restricted", "view_all"]
 
 
+class ModelIPPolicy(LiteLLMPydanticObjectBase):
+    """Model-level IP access policy."""
+
+    model: str = Field(
+        ...,
+        description="Model name or wildcard pattern (e.g. `anthropic/*`) to apply IP restrictions to.",
+    )
+    allow_cidrs: List[str] = Field(
+        ...,
+        description="List of CIDR ranges allowed to call the model.",
+    )
+
+
 class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     """
     Documents all the fields supported by `general_settings` in config.yaml
@@ -2121,6 +2134,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     mcp_trusted_proxy_ranges: Optional[List[str]] = Field(
         None,
         description="CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For headers are only trusted from these IPs.",
+    )
+    model_ip_policies: Optional[List[ModelIPPolicy]] = Field(
+        default=None,
+        description="Per-model IP allow policies. If request model matches policy `model`, caller IP must be in one of `allow_cidrs`.",
     )
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -62,7 +62,7 @@ from litellm.router import Router
 from litellm.utils import get_utc_datetime
 
 from .auth_checks_organization import organization_role_based_access_check
-from .auth_utils import get_model_from_request
+from .auth_utils import check_model_ip_policy, get_model_from_request
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span as _Span
@@ -203,6 +203,20 @@ async def common_checks(
     _model: Optional[Union[str, List[str]]] = get_model_from_request(
         request_body, route
     )
+
+    # 0. If model has IP-based policy, check caller IP
+    is_valid_model_ip, requester_ip, denied_model = check_model_ip_policy(
+        model=_model,
+        request=request,
+        general_settings=general_settings,
+    )
+    if not is_valid_model_ip:
+        raise ProxyException(
+            message=f"Access forbidden: Model {denied_model} not allowed for IP {requester_ip}.",
+            type=ProxyErrorTypes.auth_error,
+            param="model",
+            code=status.HTTP_403_FORBIDDEN,
+        )
 
     # 1. If team is blocked
     if team_object is not None and team_object.blocked is True:

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1,8 +1,9 @@
 import os
+import ipaddress
 import re
 import sys
 from functools import lru_cache
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import HTTPException, Request, status
 
@@ -48,6 +49,87 @@ def _check_valid_ip(
         return False, client_ip
 
     return True, client_ip
+
+
+def _ip_in_cidr_ranges(client_ip: Optional[str], cidr_ranges: List[str]) -> bool:
+    """Return True when client_ip is in any configured CIDR range."""
+    if not client_ip:
+        return False
+
+    # XFF chains can include commas. leftmost = original client.
+    if "," in client_ip:
+        client_ip = client_ip.split(",")[0].strip()
+
+    try:
+        parsed_ip = ipaddress.ip_address(client_ip.strip())
+    except ValueError:
+        return False
+
+    for cidr in cidr_ranges:
+        try:
+            if parsed_ip in ipaddress.ip_network(cidr, strict=False):
+                return True
+        except ValueError:
+            verbose_proxy_logger.warning(
+                "Invalid CIDR in model_ip_policies allow_cidrs: %s", cidr
+            )
+            continue
+    return False
+
+
+def _model_matches_pattern(model: str, pattern: str) -> bool:
+    if pattern == model:
+        return True
+    if pattern.endswith("*"):
+        return model.startswith(pattern[:-1])
+    return False
+
+
+def check_model_ip_policy(
+    model: Optional[Union[str, List[str]]],
+    request: Request,
+    general_settings: dict,
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Validate model-specific IP CIDR policies.
+
+    Returns:
+    - is_valid
+    - client_ip
+    - matched_model_pattern
+    """
+    model_ip_policies = general_settings.get("model_ip_policies")
+    if not model_ip_policies or model is None:
+        return True, None, None
+
+    model_list: List[str] = model if isinstance(model, list) else [model]
+    if len(model_list) == 0:
+        return True, None, None
+
+    from litellm.proxy.auth.ip_address_utils import IPAddressUtils
+
+    client_ip = IPAddressUtils.get_mcp_client_ip(
+        request=request,
+        general_settings=general_settings,
+    )
+
+    for requested_model in model_list:
+        for policy in model_ip_policies:
+            policy_model = policy.get("model") if isinstance(policy, dict) else None
+            allow_cidrs = (
+                policy.get("allow_cidrs", []) if isinstance(policy, dict) else []
+            )
+            if not policy_model or not isinstance(allow_cidrs, list):
+                continue
+
+            if not _model_matches_pattern(requested_model, policy_model):
+                continue
+
+            if _ip_in_cidr_ranges(client_ip=client_ip, cidr_ranges=allow_cidrs):
+                break
+
+            return False, client_ip, requested_model
+
+    return True, client_ip, None
 
 
 def check_complete_credentials(request_body: dict) -> bool:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -75,6 +75,7 @@ from litellm.proxy._types import (
     LiteLLM_TeamTable,
     LiteLLM_UserTable,
     LitellmUserRoles,
+    ModelIPPolicy,
     PassThroughGenericEndpoint,
     ProxyErrorTypes,
     ProxyException,
@@ -11321,6 +11322,7 @@ async def get_config_list(
         "maximum_spend_logs_retention_period": {"type": "String"},
         "mcp_internal_ip_ranges": {"type": "List"},
         "mcp_trusted_proxy_ranges": {"type": "List"},
+        "model_ip_policies": {"type": "PydanticModel"},
     }
 
     return_val = []
@@ -11334,6 +11336,8 @@ async def get_config_list(
             if typed_dict_type == "PydanticModel":
                 if field_name == "pass_through_endpoints":
                     pydantic_class_list = [PassThroughGenericEndpoint]
+                elif field_name == "model_ip_policies":
+                    pydantic_class_list = [ModelIPPolicy]
                 else:
                     pydantic_class_list = []
 

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1414,3 +1414,49 @@ async def test_get_fuzzy_user_object_case_insensitive_email():
     assert call_args.kwargs["where"]["user_email"]["equals"] == "test@example.com"
     assert call_args.kwargs["where"]["user_email"]["mode"] == "insensitive"
     assert call_args.kwargs["include"] == {"organization_memberships": True}
+
+
+@pytest.mark.parametrize(
+    "model, policies, client_ip, expected_allowed",
+    [
+        (
+            "gpt-4o",
+            [{"model": "gpt-4o", "allow_cidrs": ["10.0.0.0/8"]}],
+            "10.1.2.3",
+            True,
+        ),
+        (
+            "gpt-4o",
+            [{"model": "gpt-4o", "allow_cidrs": ["10.0.0.0/8"]}],
+            "203.0.113.10",
+            False,
+        ),
+        (
+            "anthropic/claude-3-5-sonnet",
+            [{"model": "anthropic/*", "allow_cidrs": ["172.16.0.0/12"]}],
+            "172.20.10.5",
+            True,
+        ),
+        (
+            "anthropic/claude-3-5-sonnet",
+            [{"model": "anthropic/*", "allow_cidrs": ["172.16.0.0/12"]}],
+            "192.168.1.2",
+            False,
+        ),
+    ],
+)
+def test_check_model_ip_policy(model, policies, client_ip, expected_allowed):
+    from litellm.proxy.auth.auth_utils import check_model_ip_policy
+
+    request = MagicMock()
+    general_settings = {"model_ip_policies": policies}
+
+    with patch(
+        "litellm.proxy.auth.ip_address_utils.IPAddressUtils.get_mcp_client_ip",
+        return_value=client_ip,
+    ):
+        is_valid, _, _ = check_model_ip_policy(
+            model=model, request=request, general_settings=general_settings
+        )
+
+    assert is_valid is expected_allowed


### PR DESCRIPTION
### Motivation
- Provide per-model IP allowlists so deployments can restrict access to specific LLM models by client IP/CIDR ranges.
- Surface the new setting in config schema and docs so operators can configure and understand model-level IP restrictions.

### Description
- Add a `ModelIPPolicy` Pydantic model and expose `general_settings.model_ip_policies` on `ConfigGeneralSettings` and config listing via `proxy_server` using `ModelIPPolicy`.
- Implement IP/CIDR checking helpers in `auth_utils.py` (`_ip_in_cidr_ranges`, `_model_matches_pattern`, and `check_model_ip_policy`) which use `IPAddressUtils.get_mcp_client_ip` and handle X-Forwarded-For chains and invalid CIDRs (logged as warnings).
- Enforce model-level policies in request flow by calling `check_model_ip_policy` from `common_checks` in `auth_checks.py` and raising a `403` `ProxyException` when the caller IP is disallowed for the requested model.
- Add documentation updates to `docs/proxy/config_settings.md` and `docs/proxy/ip_address.md` describing `model_ip_policies`, usage examples, wildcard support, and XFF considerations.
- Add unit tests `test_check_model_ip_policy` to `tests/test_litellm/proxy/auth/test_auth_checks.py` to validate matching, wildcard behavior, and CIDR enforcement.

### Testing
- Ran the new parametrized unit tests in `tests/test_litellm/proxy/auth/test_auth_checks.py::test_check_model_ip_policy`, which passed.
- Ran the auth-related test suite that includes the updated `test_auth_checks.py` file, and all auth tests passed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e3549524832da18826257d393db3)