### PR TITLE
Add model-level IP policies and CIDR-based allowlists for proxy access

### DIFF
--- a/docs/my-website/docs/proxy/config_settings.md
+++ b/docs/my-website/docs/proxy/config_settings.md
@@ -251,6 +251,7 @@ router_settings:
 | alerting_args | dict | Args for Slack Alerting [Doc on Slack Alerting](./alerting.md) |
 | custom_key_generate | str | Custom function for key generation [Doc on custom key generation](./virtual_keys.md#custom--key-generate) |
 | allowed_ips | List[str] | List of IPs allowed to access the proxy. If not set, all IPs are allowed. |
+| model_ip_policies | List[Dict[str, Any]] | Model-level IP policy entries. Example: `{"model": "gpt-4o", "allow_cidrs": ["10.0.0.0/8"]}`. Supports wildcard model patterns. |
 | embedding_model | str | The default model to use for embeddings - ignores model set in request |
 | default_team_disabled | boolean | If true, users cannot create 'personal' keys (keys with no team_id). |
 | alert_to_webhook_url | Dict[str] | [Specify a webhook url for each alert type.](./alerting.md#set-specific-slack-channels-per-alert-type) |

--- a/docs/my-website/docs/proxy/ip_address.md
+++ b/docs/my-website/docs/proxy/ip_address.md
@@ -26,3 +26,23 @@ general_settings:
     }
 }
 ```
+
+## Model-level IP Policies
+
+Use `model_ip_policies` to allow a model only from specific IP ranges.
+
+```yaml
+general_settings:
+  use_x_forwarded_for: true
+  mcp_trusted_proxy_ranges: ["10.0.0.0/8"]
+  model_ip_policies:
+    - model: "gpt-4o"
+      allow_cidrs: ["10.20.0.0/16", "192.168.100.0/24"]
+    - model: "anthropic/*"
+      allow_cidrs: ["172.16.0.0/12"]
+```
+
+- `model` supports exact match and wildcard patterns (e.g. `anthropic/*`).
+- `allow_cidrs` supports IPv4/IPv6 CIDR values.
+- If a request model matches a policy, the client IP must match at least one CIDR in that policy.
+- If no policy matches the model, the request is not restricted by `model_ip_policies`.

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2122,6 +2122,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For headers are only trusted from these IPs.",
     )
+    model_ip_policies: Optional[List[Dict[str, Any]]] = Field(
+        None,
+        description="Model-level IP access policies. Each item supports {'model': 'pattern', 'allow_cidrs': ['10.0.0.0/8']} and optional 'allowed_ips' for backward compatibility.",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -1,11 +1,14 @@
+import ipaddress
 import os
 import re
 import sys
+from fnmatch import fnmatch
 from functools import lru_cache
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from fastapi import HTTPException, Request, status
 
+import litellm
 from litellm import Router, provider_list
 from litellm._logging import verbose_proxy_logger
 from litellm.constants import STANDARD_CUSTOMER_ID_HEADERS
@@ -26,6 +29,49 @@ def _get_request_ip_address(
 
     return client_ip
 
+def _normalize_client_ip(client_ip: Optional[str]) -> str:
+    """Normalize client IP, handling comma-separated X-Forwarded-For chains."""
+    if not client_ip:
+        return ""
+
+    normalized_ip = client_ip.strip()
+    if "," in normalized_ip:
+        normalized_ip = normalized_ip.split(",")[0].strip()
+
+    return normalized_ip
+
+
+def _check_ip_in_allowlist(client_ip: Optional[str], allowed_ips: List[str]) -> bool:
+    """
+    Check if an IP is in allowlist entries.
+
+    Supports exact IP matching and CIDR ranges.
+    """
+    normalized_ip = _normalize_client_ip(client_ip)
+    if normalized_ip == "":
+        return False
+
+    # Backwards compatible exact-match check first
+    if normalized_ip in allowed_ips:
+        return True
+
+    try:
+        client_addr = ipaddress.ip_address(normalized_ip)
+    except ValueError:
+        return False
+
+    for allowed_entry in allowed_ips:
+        try:
+            network = ipaddress.ip_network(allowed_entry, strict=False)
+            if client_addr in network:
+                return True
+        except ValueError:
+            # Ignore malformed CIDR entries and keep checking exact matches only
+            continue
+
+    return False
+
+
 
 def _check_valid_ip(
     allowed_ips: Optional[List[str]],
@@ -44,10 +90,98 @@ def _check_valid_ip(
     )
 
     # Check if IP address is allowed
-    if client_ip not in allowed_ips:
+    if not _check_ip_in_allowlist(client_ip=client_ip, allowed_ips=allowed_ips):
         return False, client_ip
 
     return True, client_ip
+
+
+
+
+def _model_matches_policy(model: str, policy_model: str) -> bool:
+    """Supports exact and wildcard model pattern matching."""
+    return model == policy_model or fnmatch(model, policy_model)
+
+
+def _get_request_client_ip(
+    request: Request,
+    use_x_forwarded_for: Optional[bool] = False,
+    trusted_proxy_ranges: Optional[List[str]] = None,
+) -> Optional[str]:
+    """
+    Resolve client IP with optional trusted proxy enforcement for XFF.
+    """
+    if use_x_forwarded_for:
+        from litellm.proxy.auth.ip_address_utils import IPAddressUtils
+
+        return IPAddressUtils.get_mcp_client_ip(
+            request=request,
+            general_settings={
+                "use_x_forwarded_for": use_x_forwarded_for,
+                "mcp_trusted_proxy_ranges": trusted_proxy_ranges,
+            },
+        )
+
+    return _get_request_ip_address(request=request, use_x_forwarded_for=False)
+
+
+def _check_model_ip_restrictions(
+    model: Union[str, List[str], None],
+    model_ip_policies: Optional[List[Dict[str, Any]]],
+    client_ip: Optional[str],
+    llm_router: Optional[Router] = None,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Return whether the client IP can access requested model(s) under model_ip_policies.
+
+    - If no policies configured, request is allowed.
+    - If model has a matching policy, IP must be in policy allowlist.
+    - If model has no matching policy, it is unrestricted by this check.
+    """
+    if not model_ip_policies:
+        return True, None
+
+    models_to_check: List[str] = model if isinstance(model, list) else [model] if model else []
+    normalized_ip = _normalize_client_ip(client_ip)
+
+    for requested_model in models_to_check:
+        candidate_models = [requested_model]
+
+        # Include aliases for parity with model access checks
+        if requested_model in litellm.model_alias_map:
+            candidate_models.append(litellm.model_alias_map[requested_model])
+        elif llm_router and requested_model in llm_router.model_group_alias:
+            resolved_model = llm_router._get_model_from_alias(requested_model)
+            if resolved_model:
+                candidate_models.append(resolved_model)
+
+        matched_policies = []
+        for policy in model_ip_policies:
+            policy_model = policy.get("model")
+            if not isinstance(policy_model, str) or policy_model == "":
+                continue
+            if any(
+                _model_matches_policy(cand_model, policy_model)
+                for cand_model in candidate_models
+            ):
+                matched_policies.append(policy)
+
+        if len(matched_policies) == 0:
+            continue
+
+        is_allowed = False
+        for policy in matched_policies:
+            allowed_list = policy.get("allow_cidrs") or policy.get("allowed_ips") or []
+            if not isinstance(allowed_list, list):
+                continue
+            if _check_ip_in_allowlist(client_ip=normalized_ip, allowed_ips=allowed_list):
+                is_allowed = True
+                break
+
+        if not is_allowed:
+            return False, requested_model
+
+    return True, None
 
 
 def check_complete_credentials(request_body: dict) -> bool:
@@ -223,6 +357,26 @@ async def pre_db_read_auth_checks(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Access forbidden: IP address {passed_in_ip} not allowed.",
+        )
+
+    # Check 3.1 Check if model-level IP policies are configured
+    _requested_model = get_model_from_request(request_data=request_data, route=route)
+    _request_client_ip = _get_request_client_ip(
+        request=request,
+        use_x_forwarded_for=general_settings.get("use_x_forwarded_for", False),
+        trusted_proxy_ranges=general_settings.get("mcp_trusted_proxy_ranges"),
+    )
+    _model_ip_allowed, _blocked_model = _check_model_ip_restrictions(
+        model=_requested_model,
+        model_ip_policies=general_settings.get("model_ip_policies", None),
+        client_ip=_request_client_ip,
+        llm_router=llm_router,
+    )
+
+    if not _model_ip_allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access forbidden: IP address {_request_client_ip} not allowed for model {_blocked_model}.",
         )
 
     # Check 4. Check if request route is an allowed route on the proxy

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -11321,6 +11321,7 @@ async def get_config_list(
         "maximum_spend_logs_retention_period": {"type": "String"},
         "mcp_internal_ip_ranges": {"type": "List"},
         "mcp_trusted_proxy_ranges": {"type": "List"},
+        "model_ip_policies": {"type": "List"},
     }
 
     return_val = []

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -32,7 +32,7 @@ class Request:
     def __init__(self, client_ip: Optional[str] = None, headers: Optional[dict] = None):
         self.client = MagicMock()
         self.client.host = client_ip
-        self.headers: Dict[str, str] = {}
+        self.headers: Dict[str, str] = headers or {}
 
 
 @pytest.mark.parametrize(
@@ -58,6 +58,60 @@ def test_check_valid_ip(
     request = Request(client_ip)
 
     assert _check_valid_ip(allowed_ips, request)[0] == expected_result  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "allowed_ips, client_ip, expected_result",
+    [
+        (["10.0.0.0/8"], "10.1.2.3", True),
+        (["10.0.0.0/8"], "11.1.2.3", False),
+        (["192.168.1.0/24", "10.0.0.0/8"], "192.168.1.10", True),
+        (["invalid-cidr", "127.0.0.1"], "127.0.0.1", True),
+    ],
+)
+def test_check_valid_ip_with_cidr(
+    allowed_ips: Optional[List[str]], client_ip: Optional[str], expected_result: bool
+):
+    from litellm.proxy.auth.auth_utils import _check_valid_ip
+
+    request = Request(client_ip)
+
+    assert _check_valid_ip(allowed_ips, request)[0] == expected_result  # type: ignore
+
+
+def test_check_model_ip_restrictions():
+    from litellm.proxy.auth.auth_utils import _check_model_ip_restrictions
+
+    policies = [
+        {"model": "gpt-4o", "allow_cidrs": ["10.0.0.0/8"]},
+        {"model": "anthropic/*", "allow_cidrs": ["192.168.0.0/16"]},
+    ]
+
+    is_allowed, blocked_model = _check_model_ip_restrictions(
+        model="gpt-4o", model_ip_policies=policies, client_ip="10.1.1.1"
+    )
+    assert is_allowed is True
+    assert blocked_model is None
+
+    is_allowed, blocked_model = _check_model_ip_restrictions(
+        model="gpt-4o", model_ip_policies=policies, client_ip="8.8.8.8"
+    )
+    assert is_allowed is False
+    assert blocked_model == "gpt-4o"
+
+    is_allowed, blocked_model = _check_model_ip_restrictions(
+        model="anthropic/claude-3-5-sonnet",
+        model_ip_policies=policies,
+        client_ip="192.168.10.10",
+    )
+    assert is_allowed is True
+    assert blocked_model is None
+
+    is_allowed, blocked_model = _check_model_ip_restrictions(
+        model="gpt-3.5-turbo", model_ip_policies=policies, client_ip="8.8.8.8"
+    )
+    assert is_allowed is True
+    assert blocked_model is None
 
 
 # test x-forwarder for is used when user has opted in


### PR DESCRIPTION
### Motivation

- Introduce model-level IP access controls so specific LLM models can be restricted to client IP ranges, and improve IP allowlist handling with CIDR support for both global and model-level rules.

### Description

- Add `model_ip_policies` to config docs (`docs/.../config_settings.md` and `docs/.../ip_address.md`) with usage examples and semantics for wildcard model patterns and CIDR ranges.
- Add `model_ip_policies` to the `ConfigGeneralSettings` pydantic model in `litellm/proxy/_types.py` so the setting is recognized and validated by the config system.
- Implement IP utilities and model-level policy enforcement in `litellm/proxy/auth/auth_utils.py`, including normalized X-Forwarded-For handling, CIDR allowlist checks using `ipaddress`, wildcard model matching via `fnmatch`, trusted proxy resolution via `IPAddressUtils.get_mcp_client_ip`, and the `_check_model_ip_restrictions` routine that blocks requests when a model has policies that do not include the client IP.
- Surface `model_ip_policies` in the config API response generation in `litellm/proxy/proxy_server.py` by allowing the argument in `allowed_args` processing so it can be displayed/edited in the config list UI.
- Update unit tests (`tests/proxy_unit_tests/test_user_api_key_auth.py`) to cover CIDR-based allowlists and `model_ip_policies`, and adjust the test `Request` helper to accept headers.

### Testing

- Ran the updated unit tests in `tests/proxy_unit_tests/test_user_api_key_auth.py` via `pytest` which executed the new CIDR and model-policy tests and they passed.
- Existing proxy unit tests were run locally and remained green after changes and additions in `auth_utils.py` and type/schema updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e3549524832da18826257d393db3)